### PR TITLE
issue #8 : check if sockaddr_ptr is NULL

### DIFF
--- a/ifaddr/_shared.py
+++ b/ifaddr/_shared.py
@@ -160,20 +160,20 @@ else:
     
     
 def sockaddr_to_ip(sockaddr_ptr):
-    if sockaddr_ptr[0].sa_familiy == socket.AF_INET:
-        ipv4 = ctypes.cast(sockaddr_ptr, ctypes.POINTER(sockaddr_in))
-        ippacked = bytes(bytearray(ipv4[0].sin_addr))
-        ip = str(ipaddress.ip_address(ippacked))
-        return ip
-    elif sockaddr_ptr[0].sa_familiy == socket.AF_INET6:
-        ipv6 = ctypes.cast(sockaddr_ptr, ctypes.POINTER(sockaddr_in6))
-        flowinfo = ipv6[0].sin6_flowinfo
-        ippacked = bytes(bytearray(ipv6[0].sin6_addr))
-        ip = str(ipaddress.ip_address(ippacked))
-        scope_id = ipv6[0].sin6_scope_id
-        return(ip, flowinfo, scope_id)
-    else:
-        return None
+    if sockaddr_ptr:
+        if sockaddr_ptr[0].sa_familiy == socket.AF_INET:
+            ipv4 = ctypes.cast(sockaddr_ptr, ctypes.POINTER(sockaddr_in))
+            ippacked = bytes(bytearray(ipv4[0].sin_addr))
+            ip = str(ipaddress.ip_address(ippacked))
+            return ip
+        elif sockaddr_ptr[0].sa_familiy == socket.AF_INET6:
+            ipv6 = ctypes.cast(sockaddr_ptr, ctypes.POINTER(sockaddr_in6))
+            flowinfo = ipv6[0].sin6_flowinfo
+            ippacked = bytes(bytearray(ipv6[0].sin6_addr))
+            ip = str(ipaddress.ip_address(ippacked))
+            scope_id = ipv6[0].sin6_scope_id
+            return(ip, flowinfo, scope_id)
+    return None
 
 
 def ipv6_prefixlength(address):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ else:
 
 setup(
     name = 'ifaddr',
-    version = '0.1.3',
+    version = '0.1.4-dev',
     description='Enumerates all IP addresses on all network adapters of the system.',
     long_description=long_description,
     author='Stefan C. Mueller',


### PR DESCRIPTION
I ran into this NULL issue on a ubuntu 12 system and after debugging the issue I saw that the server had many interfaces and perhaps one of them was disabled or invalid config and therefore causing get_adapters to panic

after adding the check "ifaddr" is able to list all valid and active adapters
 