### PR TITLE
Restrict ipaddress dependency to Python < 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
     author_email='scm@smurn.org',
     url='https://github.com/pydron/ifaddr',
     packages = find_packages(),
-    install_requires = ['ipaddress'],
+    install_requires = ['ipaddress;python_version<"3.3"'],
 )


### PR DESCRIPTION
# Problem

`ifaddr` [depends on the `ipaddress` module](https://github.com/pydron/ifaddr/blob/e6163693b6b6d85aad711c3a6849ce7e3bc80d01/setup.py#L39). Before Python 3.3, ipaddress was a separate module, but it’s [now shipped with vanilla Python](https://docs.python.org/3/library/ipaddress.html):

> ### `ipaddress` — IPv4/IPv6 manipulation library
>
> …
>
> *New in version 3.3.*

This means that from Python 3.3 onward, it’s not necessary to add `ipaddress` as an install dependency anymore.

More than that, the explicit dependency is problematic, because users of Python 3.3 and newer will get an error message. The reason is that `ipaddress` won’t be found as a separate module anymore, even though it’s implicitly available.

For instance, running [`python-miio`](https://github.com/rytilahti/python-miio), which transitively depends on `ifaddr`, yields the following error on a system with Python 3.7:

```
Traceback (most recent call last):
  File "/usr/bin/mirobo", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3126, in <module>
    @_call_aside
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3110, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3139, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 581, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 898, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 784, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'ipaddress' distribution was not found and is required by ifaddr
```

# Solution

This patch restricts the `ipaddress` install dependency to Python versions before 3.3. In this way, users of Python earlier than 3.3 will still be required to get the ipaddress module backport, whereas users of newer Python versions won’t be bothered with error messages.

I’ve tested that the relaxed dependency requirement fixes the above problem that I encountered with `python-miio`.