### PR TITLE
Add OpenBSD support to ifaddr

### DIFF
--- a/ifaddr/_shared.py
+++ b/ifaddr/_shared.py
@@ -112,9 +112,9 @@ class IP(object):
         
 
 
-if platform.system() == "Darwin":
+if platform.system() == "Darwin" or platform.system() == "OpenBSD":
     
-    # Darwin uses marginally different structures
+    # Darwin and OpenBSD use marginally different structures
     # than either Linux or Windows.
     # I still keep it in `shared` since we can use
     # both structures equally.


### PR DESCRIPTION
This allows the `sockaddr_to_ip` call to work on
OpenBSD.  Before this patch, the call returns "None" and after it
returns the IP addresses associated with the interfaces.

Before the change, unit tests don't pass on OpenBSD, after the change tests pass. 