### PR TITLE
Fixes setup.py install_requires line to not be dependant on a setup tools version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,19 @@
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+import sys
 import os.path
 from setuptools import setup, find_packages
 
@@ -36,5 +37,5 @@ setup(
     author_email='scm@smurn.org',
     url='https://github.com/pydron/ifaddr',
     packages = find_packages(),
-    install_requires = ['ipaddress;python_version<"3.3"'],
+    requires = ['ipaddress'] if sys.version_info[:2] < (3, 3) else [],
 )


### PR DESCRIPTION
A user had reported that the install_requires= line of the setup causes
issues #14. this is due to various setup tools versions supporting varying syntax for the data being passed. 

This update changes it so that the testing of the python version happens in the ifaddr package and not in setuptools. This is a far better way to go about it due to the very large number of setup tools versions  available. of which different versions support different mechanisms of parsing the data in the install_requires parameter, but also install_requires as a parameter might not be supported either.

so the 2 choices would be to check the setup tools version and if it is not up to snuff then throw an error. or simply use a different mechanism like I have to not have to worry about any of the setup tools versions.
