### PR TITLE
Add an option to include ip-less adapters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,12 +71,12 @@ property.  For example:
     adapters = ifaddr.get_adapters(include_unconfigured=True)
 
     for adapter in adapters:
-        print "IPs of network adapter " + adapter.nice_name
+        print("IPs of network adapter " + adapter.nice_name)
         if adapter.ips:
             for ip in adapter.ips:
-                print "   %s/%s" % (ip.ip, ip.network_prefix)
+                print("   %s/%s" % (ip.ip, ip.network_prefix))
         else:
-            print "  No IPs configured"
+            print("  No IPs configured")
 
 
 -------------

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ ifaddr - Enumerate network interfaces/adapters and their IP addresses
 .. image:: https://codecov.io/gh/pydron/ifaddr/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/pydron/ifaddr
 
-`ifaddr` is a small Python library that allows you to find all the
+`ifaddr` is a small Python library that allows you to find all the Ethernet and
 IP addresses of the computer. It is tested on **Linux**, **OS X**, and
 **Windows**. Other BSD derivatives like **OpenBSD**, **FreeBSD**, and
 **NetBSD** should work too, but I haven't personally tested those.
@@ -58,6 +58,26 @@ This will print:
 	
 You get both IPv4 and IPv6 addresses. The later complete with
 flowinfo and scope_id.
+
+If you wish to include network interfaces that do not have a configured IP
+addresss, pass the `include_unconfigured` parameter to `get_adapters()`.
+Adapters with no configured IP addresses will have an zero-length `ips`
+property.  For example:
+
+.. code-block:: python
+
+    import ifaddr
+
+    adapters = ifaddr.get_adapters(include_unconfigured=True)
+
+    for adapter in adapters:
+        print "IPs of network adapter " + adapter.nice_name
+        if adapter.ips:
+            for ip in adapter.ips:
+                print "   %s/%s" % (ip.ip, ip.network_prefix)
+        else:
+            print "  No IPs configured"
+
 
 -------------
 Documentation

--- a/ifaddr/_posix.py
+++ b/ifaddr/_posix.py
@@ -39,7 +39,7 @@ ifaddrs._fields_ = [('ifa_next', ctypes.POINTER(ifaddrs)),
 
 libc = ctypes.CDLL(ctypes.util.find_library("socket" if os.uname()[0] == "SunOS" else "c"), use_errno=True)
 
-def get_adapters():
+def get_adapters(include_unconfigured=False):
 
     addr0 = addr = ctypes.POINTER(ifaddrs)()
     retval = libc.getifaddrs(ctypes.byref(addr))
@@ -57,7 +57,8 @@ def get_adapters():
                 index = None
             ips[adapter_name] = shared.Adapter(adapter_name, adapter_name, [],
                                                index=index)
-        ips[adapter_name].ips.append(ip)
+        if ip is not None:
+            ips[adapter_name].ips.append(ip)
 
 
     while addr:
@@ -84,6 +85,9 @@ def get_adapters():
                 prefixlen = ipaddress.IPv4Network(netmaskStr).prefixlen
             ip = shared.IP(ip, prefixlen, name)
             add_ip(name, ip)
+        else:
+            if include_unconfigured:
+                add_ip(name, None)
         addr = addr[0].ifa_next
 
     libc.freeifaddrs(addr0)

--- a/ifaddr/_win32.py
+++ b/ifaddr/_win32.py
@@ -88,7 +88,7 @@ def enumerate_interfaces_of_adapter(nice_name, address):
         yield shared.IP(ip, network_prefix, nice_name)
 
 
-def get_adapters():
+def get_adapters(include_unconfigured=False):
 
     # Call GetAdaptersAddresses() with error and buffer size handling
 
@@ -126,6 +126,9 @@ def get_adapters():
             ips = enumerate_interfaces_of_adapter(adapter_info.FriendlyName, adapter_info.FirstUnicastAddress[0])
             ips = list(ips)
             result.append(shared.Adapter(name, nice_name, ips,
+                                         index=index))
+        elif include_unconfigured:
+            result.append(shared.Adapter(name, nice_name, [],
                                          index=index))
 
     return result

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ else:
 
 setup(
     name = 'ifaddr',
-    version = '0.1.7',
+    version = '0.1.6',
     description='Cross-platform network interface and IP address enumeration library',
     long_description=long_description,
     author='Stefan C. Mueller',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ else:
 
 setup(
     name = 'ifaddr',
-    version = '0.1.6',
+    version = '0.1.7',
     description='Cross-platform network interface and IP address enumeration library',
     long_description=long_description,
     author='Stefan C. Mueller',


### PR DESCRIPTION
Sometimes it's useful to know the MAC address of an interface
even if it does not have an IP configured