### PR TITLE
Update example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,3 @@
-
-
 ifaddr - Enumerate IP addresses on the local network adapters
 =============================================================
 
@@ -19,15 +17,15 @@ Let's get going!
 
 .. code-block:: python
 
-   import ifaddr
-   
-   adapters = ifaddr.get_adapters()
-   
-   for adapter in adapters:
-       print "IPs of network adapter " + adapter.nice_name
-       for ip in adapter.ips:
-           print "   %s/%s" % (ip.ip, ip.network_prefix)
-   
+    import ifaddr
+
+    adapters = ifaddr.get_adapters()
+
+    for adapter in adapters:
+        print ("IPs of network adapter " + adapter.nice_name)
+        for ip in adapter.ips:
+            print ("   %s/%s" % (ip.ip, ip.network_prefix))
+
 This will print:
 
 .. code-block:: python
@@ -44,12 +42,12 @@ This will print:
 	IPs of network adapter Software Loopback Interface 1
 	   IP ('::1', 0L, 0L)/128
 	   IP 127.0.0.1/8
-	   
+
 You get both IPv4 and IPv6 addresses. The later complete with
 flowinfo and scope_id.
 
 -------------
-Documentation 
+Documentation
 -------------
 
 The complete documentation (there isn't much to document) can be found here:
@@ -60,14 +58,11 @@ Bug Reports and other contributions
 -----------------------------------
 
 This project is hosted here `ifaddr github page <https://github.com/smurn/ifaddr>`_.
- 
+
 ------------
 Alternatives
 ------------
 
-Alastair Houghton develops `netifaces  <https://pypi.python.org/pypi/netifaces>`_ 
+Alastair Houghton develops `netifaces  <https://pypi.python.org/pypi/netifaces>`_
 which can do  everything this library can, and more. The only drawback is that it needs
 to be compiled, which can make the installation difficult.
-
-
-

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,14 +20,14 @@ Let's get going!
 .. code-block:: python
 
    import ifaddr
-   
+
    adapters = ifaddr.get_adapters()
-   
+
    for adapter in adapters:
-       print "IPs of network adapter " + adapter.nice_name
+       print ("IPs of network adapter " + adapter.nice_name)
        for ip in adapter.ips:
-           print "   %s/%s" % (ip.ip, ip.network_prefix)
-   
+           print ("   %s/%s" % (ip.ip, ip.network_prefix))
+
 This will print:
 
 .. code-block:: none
@@ -44,7 +44,7 @@ This will print:
 	IPs of network adapter Software Loopback Interface 1
 	   IP ('::1', 0L, 0L)/128
 	   IP 127.0.0.1/8
-	   
+
 You get both IPv4 and IPv6 addresses. The later complete with
 flowinfo and scope_id.
 
@@ -57,18 +57,18 @@ The library has only one function:
 .. py:function:: ifaddr.get_adapters()
 
    Receives all the network adapters with their IP addresses.
-   
+
    :returns: List of :class:`ifaddr.Adapter` instances in the order
      they are provided by the operating system.
-     
+
 And two simple classes:
-     
+
 .. autoclass:: ifaddr.Adapter
    :members: name, ips, nice_name
-   
+
 .. autoclass:: ifaddr.IP
    :members: ip, network_prefix, nice_name
-   
+
 -----------------------------------
 Bug Reports and other contributions
 -----------------------------------
@@ -79,8 +79,6 @@ This project is hosted here `ifaddr github page <https://github.com/smurn/ifaddr
 Alternatives
 ------------
 
-Alastair Houghton develops `netifaces  <https://pypi.python.org/pypi/netifaces>`_ 
+Alastair Houghton develops `netifaces  <https://pypi.python.org/pypi/netifaces>`_
 which can do  everything this library can, and more. The only drawback is that it needs
 to be compiled, which can make the installation difficult.
-
-


### PR DESCRIPTION
I tried the provided example on Python 3.7.2, but it says these two syntax errors
```
>>> for adapter in adapters:
...     print "IPs of network adapter " + adapter.nice_name
  File "<stdin>", line 2
    print "IPs of network adapter " + adapter.nice_name
                                  ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("IPs of network adapter " + adapter.nice_name)?
```

Also this one

```
...         print "   %s/%s" % (ip.ip, ip.network_prefix)
  File "<stdin>", line 4
    print "   %s/%s" % (ip.ip, ip.network_prefix)
                   ^
SyntaxError: invalid syntax
```

This PR fixes it in README and in docs.