### PR TITLE
Expose interface index

### DIFF
--- a/ifaddr/_posix.py
+++ b/ifaddr/_posix.py
@@ -24,6 +24,7 @@ import os
 import ctypes.util
 import ipaddress
 import collections
+import socket
 
 import ifaddr._shared as shared
 #from ifaddr._shared import sockaddr, Interface, sockaddr_to_ip, ipv6_prefixlength
@@ -50,7 +51,12 @@ def get_adapters():
     
     def add_ip(adapter_name, ip):
         if not adapter_name in ips:
-            ips[adapter_name] = shared.Adapter(adapter_name, adapter_name, [])
+            try:
+                index = socket.if_nametoindex(adapter_name)
+            except (OSError, AttributeError):
+                index = None
+            ips[adapter_name] = shared.Adapter(adapter_name, adapter_name, [],
+                                               index=index)
         ips[adapter_name].ips.append(ip)
     
     

--- a/ifaddr/_shared.py
+++ b/ifaddr/_shared.py
@@ -35,7 +35,7 @@ class Adapter(object):
     a IPv4 and an IPv6 IP address.
     """
     
-    def __init__(self, name, nice_name, ips):
+    def __init__(self, name, nice_name, ips, index=None):
         
         #: Unique name that identifies the adapter in the system.
         #: On Linux this is of the form of `eth0` or `eth0:1`, on
@@ -51,12 +51,16 @@ class Adapter(object):
         #: List of :class:`ifaddr.IP` instances in the order they were
         #: reported by the system.
         self.ips = ips
+
+        #: Adapter index as used by some API (e.g. IPv6 multicast group join).
+        self.index = index
         
     def __repr__(self):
-        return "Adapter(name={name}, nice_name={nice_name}, ips={ips})".format(
+        return "Adapter(name={name}, nice_name={nice_name}, ips={ips}, index={index})".format(
            name = repr(self.name),
            nice_name = repr(self.nice_name),
-           ips = repr(self.ips)
+           ips = repr(self.ips),
+           index=repr(self.index)
         )
 
 

--- a/ifaddr/_win32.py
+++ b/ifaddr/_win32.py
@@ -120,10 +120,12 @@ def get_adapters():
         
         name = adapter_info.AdapterName
         nice_name = adapter_info.Description
+        index = adapter_info.IfIndex
         
         if adapter_info.FirstUnicastAddress:
             ips = enumerate_interfaces_of_adapter(adapter_info.FriendlyName, adapter_info.FirstUnicastAddress[0])
             ips = list(ips)
-            result.append(shared.Adapter(name, nice_name, ips))
+            result.append(shared.Adapter(name, nice_name, ips,
+                                         index=index))
 
     return result


### PR DESCRIPTION
Interface index is a relatively rarely used property of an adapter.
However, it is required for cases like joining an IPv6 multicast
group, and is very tricky to get on Windows. This small change makes
working with IPv6 multicast much easier.