### PR TITLE
Fix Illumos/Solaris compatibility

### DIFF
--- a/ifaddr/_posix.py
+++ b/ifaddr/_posix.py
@@ -37,7 +37,7 @@ ifaddrs._fields_ = [('ifa_next', ctypes.POINTER(ifaddrs)),
                     ('ifa_addr', ctypes.POINTER(shared.sockaddr)),
                     ('ifa_netmask', ctypes.POINTER(shared.sockaddr))]
 
-libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+libc = ctypes.CDLL(ctypes.util.find_library("socket" if os.uname()[0] == "SunOS" else "c"), use_errno=True)
 
 def get_adapters():
 


### PR DESCRIPTION
As reported in #23 by Jorge Schrauwen on Illumos/Solaris getifaddrs and
freeifaddrs live in libsocket instead of libc, let's handle that.

Closes #23.