### PR TITLE
Build universal wheels for simplicity

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,5 @@ source-dir = doc
 build-dir  = build/doc
 all_files  = 1
 
+[wheel]
+universal = True


### PR DESCRIPTION
The project doesn't have any platform-specific native code so we might
as well build wheels that can be used everywhere.

This should allow installing the package on systems that can't install
the source distributions because of outdated setuptools.