### PR TITLE
Implement netifaces.interfaces()

### DIFF
--- a/ifaddr/netifaces.py
+++ b/ifaddr/netifaces.py
@@ -1,0 +1,8 @@
+# netifaces compatibility layer
+
+import ifaddr
+
+
+def interfaces():
+    adapters = ifaddr.get_adapters(include_unconfigured=True)
+    return [a.name for a in adapters]

--- a/ifaddr/test_ifaddr.py
+++ b/ifaddr/test_ifaddr.py
@@ -1,7 +1,20 @@
 # Copyright (C) 2015 Stefan C. Mueller
 
 import unittest
+
+import pytest
+
 import ifaddr
+import ifaddr.netifaces
+
+
+try:
+    import netifaces
+except ImportError:
+    skip_netifaces = True
+else:
+    skip_netifaces = False
+
 
 class TestIfaddr(unittest.TestCase):
     """
@@ -22,3 +35,14 @@ class TestIfaddr(unittest.TestCase):
                     found = True
 
         self.assertTrue(found, "No adapter has IP 127.0.0.1: %s" % str(adapters))
+
+
+@pytest.mark.skipif(skip_netifaces, reason='netifaces not installed')
+def test_netifaces_compatibility():
+    interfaces = ifaddr.netifaces.interfaces()
+    assert interfaces == netifaces.interfaces()
+    # TODO: implement those as well
+    # for interface in interfaces:
+    #     print(interface)
+    #     assert ifaddr.netifaces.ifaddresses(interface) == netifaces.ifaddresses(interface)
+    # assert ifaddr.netifaces.gateways() == netifaces.gateways()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
+# netifaces only provides 64-bit Windows wheels for Python 3.6 and 3.7 and we use 64-bit CI builds
+netifaces;python_version=='3.6' and platform_system=='Windows' or python_version=='3.7' and platform_system=='Windows' or platform_system!='Windows'
 pytest
 pytest-cov


### PR DESCRIPTION
This is part of netifaces compatibility layer I figured would be helpful
to people trying to avoid installing netifaces while still keeping their
netifaces-using code mostly intact.