### PR TITLE
Drop Python 2.7 (including PyPy 2) and 3.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
+        python-version: [3.6, 3.7, 3.8, pypy3]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ IP addresses of the computer. It is tested on **Linux**, **OS X**, and
 **Solaris/Illumos** should also work.
 
 This library is open source and released under the MIT License. It works
-with Python 2.7 and 3.5+.
+with Python 3.6+.
 
 You can install it with `pip install ifaddr`. It doesn't need to
 compile anything, so there shouldn't be any surprises. Even on Windows.

--- a/ifaddr/_posix.py
+++ b/ifaddr/_posix.py
@@ -52,7 +52,7 @@ def get_adapters(include_unconfigured=False):
         if not adapter_name in ips:
             try:
                 index = socket.if_nametoindex(adapter_name)
-            except OSError:
+            except (OSError, AttributeError):
                 index = None
             ips[adapter_name] = shared.Adapter(adapter_name, adapter_name, [],
                                                index=index)

--- a/ifaddr/_posix.py
+++ b/ifaddr/_posix.py
@@ -19,7 +19,6 @@
 # IN THE SOFTWARE.
 
 
-import sys
 import os
 import ctypes.util
 import ipaddress
@@ -53,7 +52,7 @@ def get_adapters(include_unconfigured=False):
         if not adapter_name in ips:
             try:
                 index = socket.if_nametoindex(adapter_name)
-            except (OSError, AttributeError):
+            except OSError:
                 index = None
             ips[adapter_name] = shared.Adapter(adapter_name, adapter_name, [],
                                                index=index)
@@ -62,26 +61,17 @@ def get_adapters(include_unconfigured=False):
 
 
     while addr:
-        name = addr[0].ifa_name
-        if sys.version_info[0] > 2:
-            name = name.decode(encoding='UTF-8')
+        name = addr[0].ifa_name.decode(encoding='UTF-8')
         ip = shared.sockaddr_to_ip(addr[0].ifa_addr)
         if ip:
             if addr[0].ifa_netmask and not addr[0].ifa_netmask[0].sa_familiy:
                 addr[0].ifa_netmask[0].sa_familiy = addr[0].ifa_addr[0].sa_familiy
             netmask = shared.sockaddr_to_ip(addr[0].ifa_netmask)
             if isinstance(netmask, tuple):
-                netmask = netmask[0]
-                if sys.version_info[0] > 2:
-                    netmaskStr = str(netmask)
-                else:
-                    netmaskStr = unicode(netmask)
+                netmaskStr = str(netmask[0])
                 prefixlen = shared.ipv6_prefixlength(ipaddress.IPv6Address(netmaskStr))
             else:
-                if sys.version_info[0] > 2:
-                    netmaskStr = str('0.0.0.0/' + netmask)
-                else:
-                    netmaskStr = unicode('0.0.0.0/' + netmask)
+                netmaskStr = str('0.0.0.0/' + netmask)
                 prefixlen = ipaddress.IPv4Network(netmaskStr).prefixlen
             ip = shared.IP(ip, prefixlen, name)
             add_ip(name, ip)

--- a/ifaddr/_win32.py
+++ b/ifaddr/_win32.py
@@ -20,7 +20,6 @@
 
 
 import ctypes
-import sys
 from ctypes import wintypes
 
 import ifaddr._shared as shared
@@ -119,10 +118,8 @@ def get_adapters(include_unconfigured=False):
     result = []
     for adapter_info in address_infos:
 
-        name = adapter_info.AdapterName
-        if sys.version_info[0] > 2:
-            # We don't expect non-ascii characters here, so encoding shouldn't matter
-            name = name.decode()
+        # We don't expect non-ascii characters here, so encoding shouldn't matter
+        name = adapter_info.AdapterName.decode()
         nice_name = adapter_info.Description
         index = adapter_info.IfIndex
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,3 @@
 source-dir = doc
 build-dir  = build/doc
 all_files  = 1
-
-[wheel]
-universal = True

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     url='https://github.com/pydron/ifaddr',
     packages = find_packages(),
     license='MIT',
-    install_requires = ['ipaddress;python_version<"3.3"'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
They reached their end of life some time ago and supporting them would
make some upcoming changes more difficult than they should be.