### PR TITLE
Don't run CI on non-master branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
It's annoying when I created a PR from a branch in this repository and
all the builds run twice (once for push, once for pull_request).