### PR TITLE
Fix two type errors detected by Mypy

### DIFF
--- a/ifaddr/_posix.py
+++ b/ifaddr/_posix.py
@@ -75,6 +75,7 @@ def get_adapters(include_unconfigured: bool = False) -> Iterable[shared.Adapter]
                 netmaskStr = str(netmask[0])
                 prefixlen = shared.ipv6_prefixlength(ipaddress.IPv6Address(netmaskStr))
             else:
+                assert netmask is not None, f'sockaddr_to_ip({addr[0].ifa_netmask}) returned None'
                 netmaskStr = str('0.0.0.0/' + netmask)
                 prefixlen = ipaddress.IPv4Network(netmaskStr).prefixlen
             ip = shared.IP(ip_addr, prefixlen, name)

--- a/ifaddr/_win32.py
+++ b/ifaddr/_win32.py
@@ -85,6 +85,7 @@ def enumerate_interfaces_of_adapter(nice_name: str, address: IP_ADAPTER_UNICAST_
 
     for address in addresses:
         ip = shared.sockaddr_to_ip(address.Address.lpSockaddr)
+        assert ip is not None, f'sockaddr_to_ip({address.Address.lpSockaddr}) returned None'
         network_prefix = address.OnLinkPrefixLength
         yield shared.IP(ip, network_prefix, nice_name)
 


### PR DESCRIPTION
The errors:

    % mypy ifaddr
    ifaddr/_win32.py:89: error: Argument 1 to "IP" has incompatible type "Union[str, Tuple[str, int, int], None]"; expected "Union[str, Tuple[str, int, int]]"
    ifaddr/_posix.py:78: error: Unsupported operand types for + ("str" and "None")
    ifaddr/_posix.py:78: note: Right operand is of type "Optional[str]"
    Found 2 errors in 2 files (checked 6 source files)

In order to avoid using None there let's raise exception if the
preconditions are not met.