### PR TITLE
Enforce code formatting using Black

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         pytest
         if which mypy; then mypy ifaddr; fi
+        if which black; then black --check . ; fi
     # Coveralls won't work here trivially because it can't ingest coverage.xml, so Codecov it is.
     # https://github.com/coverallsapp/github-action/issues/30
     - name: Report coverage to Codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+black;implementation_name=="cpython"
 mypy;implementation_name=="cpython"
 # netifaces only provides 64-bit Windows wheels for Python 3.6 and 3.7 and we use 64-bit CI builds
 netifaces;python_version=='3.7' and platform_system=='Windows' or platform_system!='Windows'


### PR DESCRIPTION
Since we have the code formatted now let's make sure we don't deviate
from that.