### PR TITLE
Include the py.typed marker in the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     author_email='scm@smurn.org',
     url='https://github.com/pydron/ifaddr',
     packages=find_packages(),
+    package_data={'ifaddr': ['py.typed']},
     license='MIT',
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
The marker file express the fact the the package contains type hints and
that the type hints should be used by type checkers.