### PR TITLE
Pin developer package requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-black;implementation_name=="cpython"
-mypy;implementation_name=="cpython"
+black==22.3.0;implementation_name=="cpython"
+mypy==0.961;implementation_name=="cpython"
 # netifaces only provides 64-bit Windows wheels for Python 3.6 and 3.7 and we use 64-bit CI builds
 netifaces;python_version=='3.7' and platform_system=='Windows' or platform_system!='Windows'
-pytest
-pytest-cov
+pytest==7.1.2
+pytest-cov==3.0.0


### PR DESCRIPTION
Make CI green by pinning all development dependencies to versions which have been current at the time of the last release (0.2.0). This gives a starting point to update dev requirements along with the code base.